### PR TITLE
build: Update dependencies

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -73,7 +72,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1.1-android</version>
         </dependency>
         <dependency>
             <groupId>com.google.flogger</groupId>

--- a/plugin-maven/pom.xml
+++ b/plugin-maven/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>org.dom4j</groupId>
                 <artifactId>dom4j</artifactId>
-                <version>2.1.1</version>
+                <version>2.1.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -205,7 +205,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.20</version>
+                <version>1.18.22</version>
             </dependency>
             <dependency>
                 <groupId>uk.co.jemos.podam</groupId>
@@ -299,7 +299,7 @@
                 <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_maven-plugin_packaging -->
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>


### PR DESCRIPTION
build(deps): bump lombok from 1.18.20 to 1.18.22

Bumps [lombok](https://github.com/projectlombok/lombok) from 1.18.20 to 1.18.22.
- [Release notes](https://github.com/projectlombok/lombok/releases)
- [Changelog](https://github.com/projectlombok/lombok/blob/master/doc/changelog.markdown)
- [Commits](https://github.com/projectlombok/lombok/compare/v1.18.20...v1.18.22)

---
updated-dependencies:
- dependency-name: org.projectlombok:lombok
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump maven-plugin-annotations from 3.6.0 to 3.6.1

Bumps [maven-plugin-annotations](https://github.com/apache/maven-plugin-tools) from 3.6.0 to 3.6.1.
- [Release notes](https://github.com/apache/maven-plugin-tools/releases)
- [Commits](https://github.com/apache/maven-plugin-tools/compare/maven-plugin-tools-3.6.0...maven-plugin-tools-3.6.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugin-tools:maven-plugin-annotations
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump dom4j from 2.1.1 to 2.1.3

Bumps [dom4j](https://github.com/dom4j/dom4j) from 2.1.1 to 2.1.3.
- [Release notes](https://github.com/dom4j/dom4j/releases)
- [Commits](https://github.com/dom4j/dom4j/compare/version-2.1.1...version-2.1.3)

---
updated-dependencies:
- dependency-name: org.dom4j:dom4j
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump flogger from 0.6 to 0.7.1

Bumps [flogger](https://github.com/google/flogger) from 0.6 to 0.7.1.
- [Release notes](https://github.com/google/flogger/releases)
- [Commits](https://github.com/google/flogger/compare/flogger-0.6...flogger-0.7.1)

---
updated-dependencies:
- dependency-name: com.google.flogger:flogger
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

build(deps): bump maven-resources-plugin from 3.0.2 to 3.2.0

Bumps [maven-resources-plugin](https://github.com/apache/maven-resources-plugin) from 3.0.2 to 3.2.0.
- [Release notes](https://github.com/apache/maven-resources-plugin/releases)
- [Commits](https://github.com/apache/maven-resources-plugin/compare/maven-resources-plugin-3.0.2...maven-resources-plugin-3.2.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-resources-plugin
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>