### PR TITLE
feature: Handle Optional's with unbound generic type params

### DIFF
--- a/generator-assertions-tests/src/test/java/io/stubbs/truth/generator/GeneratedAssertionTests.java
+++ b/generator-assertions-tests/src/test/java/io/stubbs/truth/generator/GeneratedAssertionTests.java
@@ -22,7 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 /**
  * Uses output from packages completed tests run from the generator module.
  *
- * @see TruthGeneratorTest#generate_code
+ * @see TruthGeneratorTest#fullGeneratedCode
  */
 public class GeneratedAssertionTests {
 
@@ -95,7 +95,7 @@ public class GeneratedAssertionTests {
         MyEmployee emp = TestModelUtils.createInstance(MyEmployee.class)
                 // not sure how or why, but PODAM is always setting our FALSE test boolean to true, so... ->
                 .toBuilder().testBooleanIsFalse(false).build();
-        String santity = emp.getSantity();
+        String santity = emp.getSanity();
         boolean boss = emp.isBoss();
         boolean testBoolean = emp.isTestBooleanIsFalse();
 

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -113,6 +113,11 @@
             <artifactId>javassist</artifactId>
             <version>3.28.0-GA</version>
         </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>typetools</artifactId>
+            <version>0.6.3</version>
+        </dependency>
 
         <!-- Test -->
         <dependency>
@@ -121,6 +126,20 @@
             <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.11</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test Cases -->
+        <!--        <dependency>-->
+        <!--            <groupId>io.confluent.parallelconsumer</groupId>-->
+        <!--            <artifactId>parallel-consumer-core</artifactId>-->
+        <!--            <version>0.4.0.1</version>-->
+        <!--            <scope>test</scope>-->
+        <!--        </dependency>-->
     </dependencies>
 
     <build>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -132,14 +132,6 @@
             <version>1.2.11</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- Test Cases -->
-        <!--        <dependency>-->
-        <!--            <groupId>io.confluent.parallelconsumer</groupId>-->
-        <!--            <artifactId>parallel-consumer-core</artifactId>-->
-        <!--            <version>0.4.0.1</version>-->
-        <!--            <scope>test</scope>-->
-        <!--        </dependency>-->
     </dependencies>
 
     <build>

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/AssertionMethodStrategy.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/AssertionMethodStrategy.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.reflect.Modifier.STATIC;
-import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
 import static org.reflections.util.ReflectionUtilsPredicates.withModifier;
 
 /**
@@ -22,17 +21,13 @@ import static org.reflections.util.ReflectionUtilsPredicates.withModifier;
  */
 public abstract class AssertionMethodStrategy {
 
-    protected abstract boolean addStrategyMaybe(ThreeSystem<?> threeSystem, Method method, JavaClassSource generated);
+    public abstract boolean addStrategyMaybe(ThreeSystem<?> threeSystem, Method method, JavaClassSource generated);
 
     protected void copyThrownExceptions(Method method, MethodSource<JavaClassSource> generated) {
         Class<? extends Exception>[] exceptionTypes = (Class<? extends Exception>[]) method.getExceptionTypes();
         Stream<Class<? extends Exception>> runtimeExceptions = Arrays.stream(exceptionTypes)
                 .filter(x -> !RuntimeException.class.isAssignableFrom(x));
         runtimeExceptions.forEach(generated::addThrows);
-    }
-
-    protected Class<?> getWrappedReturnType(Method method) {
-        return primitiveToWrapper(method.getReturnType());
     }
 
     protected boolean methodIsStatic(Method method) {

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/BooleanStrategy.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/BooleanStrategy.java
@@ -20,7 +20,7 @@ import static org.apache.commons.lang3.StringUtils.removeStart;
 public class BooleanStrategy extends AssertionMethodStrategy {
 
     @Override
-    protected boolean addStrategyMaybe(ThreeSystem<?> threeSystem, Method method, JavaClassSource generated) {
+    public boolean addStrategyMaybe(ThreeSystem<?> threeSystem, Method method, JavaClassSource generated) {
         var positive = addBooleanGeneric(threeSystem, method, generated, true);
         var negative = addBooleanGeneric(threeSystem, method, generated, false);
         return positive.isPresent() && negative.isPresent();

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
@@ -72,15 +72,15 @@ public class JDKOverrideAnalyser {
 
         try {
             String name = clazz.getCanonicalName();
-            //noinspection OptionalGetWithoutIsPresent
+            //noinspection OptionalGetWithoutIsPresent - checked in isOverrideConfigured
             var locate = ClassFileLocator.ForJarFile
-                    .of(options.getRuntimeJavaClassSourceOverride().get())
+                    .of(options.getRuntimeJavaClassSourceOverride().get()) // NOSONAR
                     .locate(name);
             byte[] resolve = locate.resolve();
             ClassFile classRepresentation = new ClassFile(new DataInputStream(new ByteArrayInputStream(resolve)));
             return of(classRepresentation);
         } catch (IOException e) {
-            log.error("Can't load class override for {} from {}", clazz, options.getRuntimeJavaClassSourceOverride().get());
+            log.error("Can't load class override for {} from {}", clazz, options.getRuntimeJavaClassSourceOverride().get()); // NOSONAR
             return empty();
         }
     }

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/OptionalStrategy.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/OptionalStrategy.java
@@ -2,6 +2,7 @@ package io.stubbs.truth.generator.internal;
 
 import io.stubbs.truth.generator.internal.model.ThreeSystem;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ClassUtils;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 
@@ -19,8 +20,8 @@ import static org.apache.commons.lang3.StringUtils.removeStart;
 public class OptionalStrategy extends AssertionMethodStrategy {
 
     @Override
-    protected boolean addStrategyMaybe(ThreeSystem threeSystem, Method method, JavaClassSource generated) {
-        if (Optional.class.isAssignableFrom(getWrappedReturnType(method))) {
+    public boolean addStrategyMaybe(ThreeSystem threeSystem, Method method, JavaClassSource generated) {
+        if (Optional.class.isAssignableFrom(ClassUtils.primitiveToWrapper(method.getReturnType()))) {
             addOptionalStrategy(method, generated);
             return true;
         }

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/Utils.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/Utils.java
@@ -36,7 +36,7 @@ public class Utils {
         try (PrintWriter out = new PrintWriter(fileName.toFile())) {
             out.println(classSource);
         } catch (FileNotFoundException e) {
-            throw new IllegalStateException(format("Cannot write to file %s", fileName));
+            throw new IllegalStateException(format("Cannot write to file %s", fileName), e);
         }
         return classSource;
     }

--- a/generator/src/test/java/io/stubbs/truth/generator/TestModelUtils.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/TestModelUtils.java
@@ -2,12 +2,19 @@ package io.stubbs.truth.generator;
 
 import io.stubbs.truth.generator.testModel.IdCard;
 import io.stubbs.truth.generator.testModel.MyEmployee;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
+import java.lang.reflect.Method;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.stubbs.truth.generator.testModel.IdCard.SecurityType.Type.FOB;
+import static java.util.stream.Collectors.toList;
 
 /**
  * @author Antony Stubbs
@@ -37,5 +44,18 @@ public class TestModelUtils {
     public static <T> T createInstance(Class<T> type) {
         return factory.manufacturePojoWithFullData(type);
     }
+
+
+    public static MethodSource<JavaClassSource> findMethod(JavaClassSource generatedParent, String name) {
+        List<MethodSource<JavaClassSource>> collect = generatedParent.getMethods().stream().filter(x -> x.getName().equals(name)).collect(toList());
+        assertThat(collect).hasSize(1);
+        return collect.get(0);
+    }
+
+
+    public static <T> Method findMethod(Class<T> classType, String methodName) {
+        return Arrays.stream(classType.getMethods()).filter(x -> x.getName().equals(methodName)).findFirst().get();
+    }
+
 
 }

--- a/generator/src/test/java/io/stubbs/truth/generator/internal/CustomClassPathSubjects.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/internal/CustomClassPathSubjects.java
@@ -1,0 +1,33 @@
+package io.stubbs.truth.generator.internal;
+
+import io.stubbs.truth.generator.TestModelUtils;
+import io.stubbs.truth.generator.subjects.MyMapSubject;
+import io.stubbs.truth.generator.testModel.MyEmployee;
+import io.stubbs.truth.generator.testModel.Project;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class CustomClassPathSubjects {
+
+    GeneratedSubjectTypeStore subjects = new GeneratedSubjectTypeStore(Set.of(), new BuiltInSubjectTypeStore());
+
+    /**
+     * @see MyEmployee#getTypeParamTest()
+     */
+    @Test
+    public void subclass() {
+        // for reference
+        MyEmployee employee = TestModelUtils.createEmployee();
+        Map<String, Project> projectMap = employee.getProjectMap();
+
+        //
+        Method getProjectMap = TestModelUtils.findMethod(MyEmployee.class, "getProjectMap");
+        var subjectForType = subjects.getSubjectForType(getProjectMap.getReturnType());
+        assertThat(subjectForType.get().getClazz()).isEqualTo(MyMapSubject.class);
+    }
+}

--- a/generator/src/test/java/io/stubbs/truth/generator/internal/OptionalUnwrapChainForGenericTypeArgsTest.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/internal/OptionalUnwrapChainForGenericTypeArgsTest.java
@@ -1,0 +1,90 @@
+package io.stubbs.truth.generator.internal;
+
+import com.google.common.truth.Subject;
+import com.google.common.truth.Truth8;
+import io.stubbs.truth.generator.internal.model.ThreeSystem;
+import io.stubbs.truth.generator.subjects.MyMapSubject;
+import io.stubbs.truth.generator.subjects.MyStringSubject;
+import io.stubbs.truth.generator.testModel.MyEmployee;
+import io.stubbs.truth.generator.testModel.Person;
+import lombok.SneakyThrows;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.stubbs.truth.generator.TestModelUtils.findMethod;
+
+/**
+ * Not possible to unwrap an Optional<TYPE> return type for a class with type parameters. Can only do so with a subtype
+ * where the type parameter has been set.
+ */
+public class OptionalUnwrapChainForGenericTypeArgsTest {
+
+    GeneratedSubjectTypeStore subjects = new GeneratedSubjectTypeStore(Set.of(), new BuiltInSubjectTypeStore());
+
+    /**
+     * @see MyEmployee#getTypeParamTest()
+     */
+    @Test
+    public void subclass() {
+        var resolvedPair = testResolution(MyEmployee.class, "getTypeParamTest", String.class);
+        Truth8.assertThat(resolvedPair.getSubject()).isPresent();
+        assertThat(resolvedPair.getSubject().get().getClazz()).isEqualTo(MyStringSubject.class);
+    }
+
+    @Test
+    public void genericReturnTypeWithoutSpecialHandling() {
+        var resolvedPair = testResolution(MyEmployee.class, "getProjectMap", Map.class);
+        Truth8.assertThat(resolvedPair.getSubject()).isPresent();
+        assertThat(resolvedPair.getSubject().get().getClazz()).isEqualTo(MyMapSubject.class);
+    }
+
+    /**
+     * @see MyEmployee#getTypeParamTestOptional()
+     */
+    @SneakyThrows
+    @Test
+    public void subclassOptional() {
+        var resolvedPair = testResolution(MyEmployee.class, "getTypeParamTestOptional", String.class);
+        Truth8.assertThat(resolvedPair.getSubject()).isPresent();
+        assertThat(resolvedPair.getSubject().get().getClazz()).isEqualTo(MyStringSubject.class);
+    }
+
+
+    /**
+     * @see MyEmployee#getTypeParamTest()
+     */
+    @Test
+    public void directClass() {
+        var resolvedPair = testResolution(Person.class, "getTypeParamTest", Object.class);
+        Truth8.assertThat(resolvedPair.getSubject()).isPresent();
+        assertThat(resolvedPair.getSubject().get().getClazz()).isEqualTo(Subject.class);
+    }
+
+
+    /**
+     * @see Person#getTypeParamTestOptional()
+     */
+    @Test
+    public void directClassOptional() {
+        var resolvedPair = testResolution(Person.class, "getTypeParamTestOptional", Object.class);
+        Truth8.assertThat(resolvedPair.getSubject()).isPresent();
+        assertThat(resolvedPair.getSubject().get().getClazz()).isEqualTo(Subject.class);
+    }
+
+    private <T> GeneratedSubjectTypeStore.ResolvedPair testResolution(Class<T> classType, String methodName, Class<?> expectedReturnType) {
+        Method getIterationStartingPoint = findMethod(classType, methodName);
+
+        ThreeSystem<T> myEmployeeThreeSystem = new ThreeSystem<T>(classType, null, null, null);
+
+        GeneratedSubjectTypeStore.ResolvedPair resolvedPair = subjects.resolveSubjectForOptionals(myEmployeeThreeSystem, getIterationStartingPoint);
+
+        assertThat(resolvedPair.getReturnType()).isEqualTo(expectedReturnType);
+        return resolvedPair;
+    }
+
+
+}

--- a/generator/src/test/java/io/stubbs/truth/generator/testModel/MyEmployee.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/testModel/MyEmployee.java
@@ -21,11 +21,10 @@ import static io.stubbs.truth.generator.testModel.MyEmployee.State.IS_A_BOSS;
 @Getter
 @Setter(AccessLevel.PRIVATE)
 @ToString
-public class MyEmployee extends Person {
+public class MyEmployee extends Person<String> {
 
-    // todo delete
     @Getter
-    String santity = "no";
+    String sanity = "no";
     @Setter(AccessLevel.PRIVATE)
     boolean testBooleanIsFalse = false;
     private UUID id = UUID.randomUUID();
@@ -42,7 +41,7 @@ public class MyEmployee extends Person {
     private int[] intArray = {0, 1, 2};
 
     public MyEmployee(@Nonnull String name, long someLongAspect, @Nonnull ZonedDateTime birthday) {
-        super(name, someLongAspect, birthday);
+        super(name, someLongAspect, birthday, Optional.of("an optional string"), "another string");
     }
 
     /**
@@ -106,7 +105,7 @@ public class MyEmployee extends Person {
 //  }
 
     public enum State {
-        EMPLOLYED, PREVIOUSLY_EMPLOYED, NEVER_EMPLOYED, IS_A_BOSS;
+        EMPLOLYED, PREVIOUSLY_EMPLOYED, NEVER_EMPLOYED, IS_A_BOSS
     }
 
 }

--- a/generator/src/test/java/io/stubbs/truth/generator/testModel/Person.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/testModel/Person.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
 /**
  * @author Antony Stubbs
@@ -12,10 +13,14 @@ import java.time.ZonedDateTime;
 @Getter
 @SuperBuilder(toBuilder = true)
 @RequiredArgsConstructor
-public class Person {
+public class Person<T> {
     protected final String name;
     protected final long someLongAspect;
     protected final ZonedDateTime birthday;
+
+    @Getter
+    protected final Optional<T> typeParamTestOptional;
+    protected final T typeParamTest;
 
     public int getBirthYear() {
         return birthday.getYear();

--- a/generator/src/test/resources/expected/MyEmployeeParentSubject.java.txt
+++ b/generator/src/test/resources/expected/MyEmployeeParentSubject.java.txt
@@ -34,6 +34,8 @@ import static io.stubbs.truth.generator.internal.autoShaded.java.time.InstantSub
 import io.stubbs.truth.generator.internal.autoShaded.java.time.InstantSubject;
 import java.time.Instant;
 import java.util.Optional;
+import static io.stubbs.truth.generator.subjects.MyStringSubject.strings;
+import static io.stubbs.truth.generator.subjects.MyStringSubject.strings;
 import com.google.common.truth.DoubleSubject;
 import io.stubbs.truth.generator.subjects.MyStringSubject;
 import com.google.common.truth.ObjectArraySubject;
@@ -360,24 +362,24 @@ public class MyEmployeeParentSubject extends Subject {
 	 * Returns the Subject for the given field type, so you can chain on other
 	 * assertions.
 	 */
-	public MyStringSubject hasSantity() {
+	public MyStringSubject hasSanity() {
 		isNotNull();
-		return check("getSantity()").about(strings()).that(actual.getSantity());
+		return check("getSanity()").about(strings()).that(actual.getSanity());
 	}
 	/**
 	 * Simple check for equality for all fields.
 	 */
-	public void hasSantityNotEqualTo(java.lang.String expected) {
-		if (!(actual.getSantity().equals(expected))) {
-			failWithActual(fact("expected Santity NOT to be equal to", expected));
+	public void hasSanityNotEqualTo(java.lang.String expected) {
+		if (!(actual.getSanity().equals(expected))) {
+			failWithActual(fact("expected Sanity NOT to be equal to", expected));
 		}
 	}
 	/**
 	 * Simple check for equality for all fields.
 	 */
-	public void hasSantityEqualTo(java.lang.String expected) {
-		if ((actual.getSantity().equals(expected))) {
-			failWithActual(fact("expected Santity to be equal to", expected));
+	public void hasSanityEqualTo(java.lang.String expected) {
+		if ((actual.getSanity().equals(expected))) {
+			failWithActual(fact("expected Sanity to be equal to", expected));
 		}
 	}
 	/**
@@ -443,6 +445,72 @@ public class MyEmployeeParentSubject extends Subject {
 	public void hasStartedAtEqualTo(java.util.Optional expected) {
 		if ((actual.getStartedAt().equals(expected))) {
 			failWithActual(fact("expected StartedAt to be equal to", expected));
+		}
+	}
+	/**
+	 * Returns the Subject for the given field type, so you can chain on other
+	 * assertions.
+	 */
+	public MyStringSubject hasTypeParamTest() {
+		isNotNull();
+		return check("getTypeParamTest()").about(strings()).that(actual.getTypeParamTest());
+	}
+	/**
+	 * Simple check for equality for all fields.
+	 */
+	public void hasTypeParamTestNotEqualTo(java.lang.Object expected) {
+		if (!(actual.getTypeParamTest().equals(expected))) {
+			failWithActual(fact("expected TypeParamTest NOT to be equal to", expected));
+		}
+	}
+	/**
+	 * Simple check for equality for all fields.
+	 */
+	public void hasTypeParamTestEqualTo(java.lang.Object expected) {
+		if ((actual.getTypeParamTest().equals(expected))) {
+			failWithActual(fact("expected TypeParamTest to be equal to", expected));
+		}
+	}
+	/**
+	 * Returns the Subject for the given field type, so you can chain on other
+	 * assertions.
+	 */
+	public MyStringSubject hasTypeParamTestOptional() {
+		isNotNull();
+		hasTypeParamTestOptionalPresent();
+		return check("getTypeParamTestOptional().get()").about(strings())
+				.that((String) actual.getTypeParamTestOptional().get());
+	}
+	/**
+	 * Checks Optional fields for presence.
+	 */
+	public void hasTypeParamTestOptionalNotPresent() {
+		if (actual.getTypeParamTestOptional().isPresent()) {
+			failWithActual(simpleFact("expected TypeParamTestOptional NOT to be present"));
+		}
+	}
+	/**
+	 * Checks Optional fields for presence.
+	 */
+	public void hasTypeParamTestOptionalPresent() {
+		if (!actual.getTypeParamTestOptional().isPresent()) {
+			failWithActual(simpleFact("expected TypeParamTestOptional to be present"));
+		}
+	}
+	/**
+	 * Simple check for equality for all fields.
+	 */
+	public void hasTypeParamTestOptionalNotEqualTo(java.util.Optional expected) {
+		if (!(actual.getTypeParamTestOptional().equals(expected))) {
+			failWithActual(fact("expected TypeParamTestOptional NOT to be equal to", expected));
+		}
+	}
+	/**
+	 * Simple check for equality for all fields.
+	 */
+	public void hasTypeParamTestOptionalEqualTo(java.util.Optional expected) {
+		if ((actual.getTypeParamTestOptional().equals(expected))) {
+			failWithActual(fact("expected TypeParamTestOptional to be equal to", expected));
 		}
 	}
 	/**


### PR DESCRIPTION
Attempts are made to generate a concrete assertion method where possible (where the type parameter can be resolved). There are potentially further improvements to be made here, but at least with this change it won't crash when it sees one.