### PR TITLE
feature: Support target release option like javac compiler

### DIFF
--- a/.run/JDKOverrideAnalyserTest.madscientest2.run.xml
+++ b/.run/JDKOverrideAnalyserTest.madscientest2.run.xml
@@ -1,0 +1,29 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="JDKOverrideAnalyserTest.madscientest2" type="JUnit" factoryName="JUnit">
+        <module name="truth-generator"/>
+        <extension name="coverage">
+            <pattern>
+                <option name="PATTERN" value="io.stubbs.truth.generator.internal.*"/>
+                <option name="ENABLED" value="true"/>
+            </pattern>
+        </extension>
+        <extension name="net.ashald.envfile">
+            <option name="IS_ENABLED" value="false"/>
+            <option name="IS_SUBST" value="false"/>
+            <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+            <option name="IS_IGNORE_MISSING_FILES" value="false"/>
+            <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+            <ENTRIES>
+                <ENTRY IS_ENABLED="true" PARSER="runconfig"/>
+            </ENTRIES>
+        </extension>
+        <option name="PACKAGE_NAME" value="io.stubbs.truth.generator.internal"/>
+        <option name="MAIN_CLASS_NAME" value="io.stubbs.truth.generator.internal.JDKOverrideAnalyserTest"/>
+        <option name="METHOD_NAME" value="madscientest"/>
+        <option name="TEST_OBJECT" value="method"/>
+        <option name="VM_PARAMETERS" value="-ea --add-exports jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED"/>
+        <method v="2">
+            <option name="Make" enabled="true"/>
+        </method>
+    </configuration>
+</component>

--- a/.run/JDKOverrideAnalyserTest.madscientest2.run.xml
+++ b/.run/JDKOverrideAnalyserTest.madscientest2.run.xml
@@ -20,7 +20,7 @@
         <option name="PACKAGE_NAME" value="io.stubbs.truth.generator.internal"/>
         <option name="MAIN_CLASS_NAME" value="io.stubbs.truth.generator.internal.JDKOverrideAnalyserTest"/>
         <option name="METHOD_NAME" value="madscientest"/>
-        <option name="TEST_OBJECT" value="method"/>
+        <option name="TEST_OBJECT" value="class"/>
         <option name="VM_PARAMETERS" value="-ea --add-exports jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED"/>
         <method v="2">
             <option name="Make" enabled="true"/>

--- a/generator-api/pom.xml
+++ b/generator-api/pom.xml
@@ -13,5 +13,8 @@
     <description>Container for classes referenced from the generated code.</description>
 
     <artifactId>truth-generator-api</artifactId>
-
+    <properties>
+        <maven.compiler.source>13</maven.compiler.source>
+        <maven.compiler.target>13</maven.compiler.target>
+    </properties>
 </project>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -14,6 +14,9 @@
 
     <properties>
         <version.roaster>2.24.0.Final</version.roaster>
+
+        <maven.compiler.source>13</maven.compiler.source>
+        <maven.compiler.target>13</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -135,6 +135,17 @@
             <version>1.2.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.core</artifactId>
+            <version>3.29.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
@@ -1,30 +1,34 @@
 package io.stubbs.truth.generator.internal;
 
 import javassist.bytecode.AccessFlag;
+import javassist.bytecode.AttributeInfo;
 import javassist.bytecode.ClassFile;
 import javassist.bytecode.MethodInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import net.bytebuddy.dynamic.ClassFileLocator;
-import one.util.streamex.StreamEx;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.internal.compiler.util.CtSym;
+import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 
+import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
-import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static java.util.Optional.*;
+import static java.util.Optional.ofNullable;
 
 /**
  * Used to test if a provided class contains a given method, when the class byte data is loaded from a configured jar,
  * instead of the runtime JDK.
  *
  * @author Antony Stubbs
- * @see Options#getRuntimeJavaClassSourceOverride()
+ * @see Options#getReleaseTarget()
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -34,8 +38,12 @@ public class JDKOverrideAnalyser {
 
     private final Map<Class<?>, ClassFile> cache = new HashMap<>();
 
+    public static Optional<MethodInfo> findMethodWithNoParamsJA(ClassFile classRepresentation, String name) {
+        return findMethodJA(classRepresentation, name, 0);
+    }
+
     public boolean doesOverrideClassContainMethod(Class<?> clazz, Method method) {
-        Optional<ClassFile> classModel = getCachedClass(clazz);
+        Optional<ClassFile> classModel = ofNullable(getClassFileEclipse(options.getReleaseTarget().get(), clazz));
 
         return classModel
                 .filter(model ->
@@ -43,50 +51,85 @@ public class JDKOverrideAnalyser {
                 .isPresent();
     }
 
-    private Optional<ClassFile> getCachedClass(Class<?> clazz) {
-        var cachedModel = ofNullable(cache.get(clazz));
-        if (cachedModel.isPresent()) {
-            return cachedModel;
-        } else {
-            Optional<ClassFile> aClass = getClass(clazz);
-            aClass.ifPresent(classFile -> cache.put(clazz, classFile));
-            return aClass;
-        }
+//    private Optional<ClassFile> getCachedClass(Class<?> clazz) {
+//        var cachedModel = ofNullable(cache.get(clazz));
+//        if (cachedModel.isPresent()) {
+//            return cachedModel;
+//        } else {
+//            Optional<ClassFile> aClass = getClass(clazz);
+//            aClass.ifPresent(classFile -> cache.put(clazz, classFile));
+//            return aClass;
+//        }
+//    }
+
+    @SneakyThrows
+    @Nullable
+    protected ClassFile getClassFileEclipse(int platformNumber, Class<?> clazz) {
+        String platformName = Integer.toString(platformNumber);
+
+        String qualifiedSigFilename = clazz.getTypeName().replace('.', '/') + ".sig";
+
+        String releaseCode = CtSym.getReleaseCode(platformName);
+        Path java_home = Path.of(System.getenv("JAVA_HOME"));
+        CtSym ctSym = JRTUtil.getCtSym(java_home);
+
+        Optional<Path> fullPath = Optional.ofNullable(ctSym.getFullPath(releaseCode, qualifiedSigFilename, clazz.getModule().getName()));
+
+        if (fullPath.isEmpty())
+            return null;
+
+        byte[] fileBytes = ctSym.getFileBytes(fullPath.get());
+        return new ClassFile(new DataInputStream(new ByteArrayInputStream(fileBytes)));
     }
+
+//    private Optional<ClassFile> getClass(Class<?> clazz) {
+//        if (!isOverrideConfigured()) {
+//            throw new IllegalStateException("No class source override configured");
+//        }
+//
+//        try {
+//            String name = clazz.getCanonicalName();
+//            //noinspection OptionalGetWithoutIsPresent - checked in isOverrideConfigured
+//            var locate = ClassFileLocator.ForJarFile
+//                    .of(options.getReleaseTarget().get()) // NOSONAR
+//                    .locate(name);
+//            byte[] resolve = locate.resolve();
+//            ClassFile classRepresentation = new ClassFile(new DataInputStream(new ByteArrayInputStream(resolve)));
+//            return of(classRepresentation);
+//        } catch (IOException e) {
+//            log.error("Can't load class override for {} from {}", clazz, options.getReleaseTarget().get()); // NOSONAR
+//            return empty();
+//        }
+//    }
 
     private boolean doesContainsMethod(ClassFile model, Method method) {
-        String needle = method.getName();
-        List<MethodInfo> methods = model.getMethods();
-        Optional<MethodInfo> matchingMethod = StreamEx.of(methods)
-                .filter(x ->
-                        x.getName().equals(needle)
-                )
-                .findFirst();
-        return matchingMethod.isPresent() && AccessFlag.isPublic(matchingMethod.get().getAccessFlags());
+        Optional<MethodInfo> methodJA = findMethodJA(model, method.getName(), method.getParameterCount());
+        return methodJA.isPresent() && AccessFlag.isPublic(methodJA.get().getAccessFlags());
     }
 
-    private Optional<ClassFile> getClass(Class<?> clazz) {
-        if (!isOverrideConfigured()) {
-            throw new IllegalStateException("No class source override configured");
-        }
+    public static Optional<MethodInfo> findMethodJA(ClassFile classRepresentation, String name, int paramCount) {
+        List<MethodInfo> methods = classRepresentation.getMethods();
+        return methods.stream().filter(x -> {
+            if (x.getName().equals(name)) {
 
-        try {
-            String name = clazz.getCanonicalName();
-            //noinspection OptionalGetWithoutIsPresent - checked in isOverrideConfigured
-            var locate = ClassFileLocator.ForJarFile
-                    .of(options.getRuntimeJavaClassSourceOverride().get()) // NOSONAR
-                    .locate(name);
-            byte[] resolve = locate.resolve();
-            ClassFile classRepresentation = new ClassFile(new DataInputStream(new ByteArrayInputStream(resolve)));
-            return of(classRepresentation);
-        } catch (IOException e) {
-            log.error("Can't load class override for {} from {}", clazz, options.getRuntimeJavaClassSourceOverride().get()); // NOSONAR
-            return empty();
-        }
+                List<AttributeInfo> attributes = x.getAttributes();
+
+                if (attributes.isEmpty() && paramCount == 0) {
+                    return true;
+                }
+
+                String descriptor = x.getDescriptor();
+                String params = StringUtils.substringBetween(descriptor, "(", ")");
+                int hackyParamCount = StringUtils.countMatches(params, ';');
+                return hackyParamCount == paramCount;
+
+            }
+            return false;
+        }).findFirst();
     }
 
     public boolean isOverrideConfigured() {
-        return options.getRuntimeJavaClassSourceOverride().isPresent();
+        return options.getReleaseTarget().isPresent();
     }
 
 }

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
@@ -37,6 +37,8 @@ public class JDKOverrideAnalyser {
     public boolean doesOverrideClassContainMethod(Class<?> clazz, Method method) {
         Optional<ClassFile> classModel = getCachedClass(clazz);
 
+        JDKPlatformProvider
+
         return classModel
                 .filter(model ->
                         doesContainsMethod(model, method))

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyser.java
@@ -37,8 +37,6 @@ public class JDKOverrideAnalyser {
     public boolean doesOverrideClassContainMethod(Class<?> clazz, Method method) {
         Optional<ClassFile> classModel = getCachedClass(clazz);
 
-        JDKPlatformProvider
-
         return classModel
                 .filter(model ->
                         doesContainsMethod(model, method))

--- a/generator/src/main/java/io/stubbs/truth/generator/internal/Options.java
+++ b/generator/src/main/java/io/stubbs/truth/generator/internal/Options.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.io.File;
 import java.util.Optional;
 
 /**
@@ -25,7 +24,7 @@ public class Options {
     @Builder.Default
     boolean compilationTargetLowerThanNine = false;
     @Builder.Default
-    Optional<File> runtimeJavaClassSourceOverride = Optional.empty();
+    Optional<Integer> releaseTarget = Optional.empty();
     /**
      * Marks whether to try to find all referenced types from the source types, to generate Subjects for all of them,
      * and use them all in the Subject tree.

--- a/generator/src/module-info.java
+++ b/generator/src/module-info.java
@@ -1,0 +1,3 @@
+module truth.generator {
+	requires java.compiler;
+}

--- a/generator/src/test/java/io/stubbs/truth/generator/TestModelUtils.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/TestModelUtils.java
@@ -2,10 +2,6 @@ package io.stubbs.truth.generator;
 
 import io.stubbs.truth.generator.testModel.IdCard;
 import io.stubbs.truth.generator.testModel.MyEmployee;
-import javassist.bytecode.AttributeInfo;
-import javassist.bytecode.ClassFile;
-import javassist.bytecode.MethodInfo;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.env.IBinaryAnnotation;
 import org.eclipse.jdt.internal.compiler.env.IBinaryMethod;
@@ -64,31 +60,6 @@ public class TestModelUtils {
 
     public static <T> Method findMethodWithNoParamsJRflect(Class<T> classType, String methodName) {
         return Arrays.stream(classType.getMethods()).filter(x -> x.getName().equals(methodName)).findFirst().get();
-    }
-
-    public static Optional<MethodInfo> findMethodWithNoParamsJA(ClassFile classRepresentation, String name) {
-        return findMethodJA(classRepresentation, name, 0);
-    }
-
-    public static Optional<MethodInfo> findMethodJA(ClassFile classRepresentation, String name, int paramCount) {
-        List<MethodInfo> methods = classRepresentation.getMethods();
-        return methods.stream().filter(x -> {
-            if (x.getName().equals(name)) {
-
-                List<AttributeInfo> attributes = x.getAttributes();
-
-                if (attributes.isEmpty() && paramCount == 0) {
-                    return true;
-                }
-
-                String descriptor = x.getDescriptor();
-                String params = StringUtils.substringBetween(descriptor, "(", ")");
-                int hackyParamCount = StringUtils.countMatches(params, ';');
-                return hackyParamCount == paramCount;
-
-            }
-            return false;
-        }).findFirst();
     }
 
     public static Optional<IBinaryMethod> findMethodWithNoParamsEclipse(ClassFileReader classRepresentation, String methodName) {

--- a/generator/src/test/java/io/stubbs/truth/generator/TestModelUtils.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/TestModelUtils.java
@@ -2,6 +2,14 @@ package io.stubbs.truth.generator;
 
 import io.stubbs.truth.generator.testModel.IdCard;
 import io.stubbs.truth.generator.testModel.MyEmployee;
+import javassist.bytecode.AttributeInfo;
+import javassist.bytecode.ClassFile;
+import javassist.bytecode.MethodInfo;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
+import org.eclipse.jdt.internal.compiler.env.IBinaryAnnotation;
+import org.eclipse.jdt.internal.compiler.env.IBinaryMethod;
+import org.eclipse.jdt.internal.compiler.env.IBinaryTypeAnnotation;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -11,6 +19,7 @@ import java.lang.reflect.Method;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.stubbs.truth.generator.testModel.IdCard.SecurityType.Type.FOB;
@@ -46,16 +55,68 @@ public class TestModelUtils {
     }
 
 
-    public static MethodSource<JavaClassSource> findMethod(JavaClassSource generatedParent, String name) {
+    public static MethodSource<JavaClassSource> findMethodWithNoParamsRoast(JavaClassSource generatedParent, String name) {
         List<MethodSource<JavaClassSource>> collect = generatedParent.getMethods().stream().filter(x -> x.getName().equals(name)).collect(toList());
         assertThat(collect).hasSize(1);
         return collect.get(0);
     }
 
 
-    public static <T> Method findMethod(Class<T> classType, String methodName) {
+    public static <T> Method findMethodWithNoParamsJRflect(Class<T> classType, String methodName) {
         return Arrays.stream(classType.getMethods()).filter(x -> x.getName().equals(methodName)).findFirst().get();
     }
 
+    public static Optional<MethodInfo> findMethodWithNoParamsJA(ClassFile classRepresentation, String name) {
+        return findMethodJA(classRepresentation, name, 0);
+    }
 
+    public static Optional<MethodInfo> findMethodJA(ClassFile classRepresentation, String name, int paramCount) {
+        List<MethodInfo> methods = classRepresentation.getMethods();
+        return methods.stream().filter(x -> {
+            if (x.getName().equals(name)) {
+
+                List<AttributeInfo> attributes = x.getAttributes();
+
+                if (attributes.isEmpty() && paramCount == 0) {
+                    return true;
+                }
+
+                String descriptor = x.getDescriptor();
+                String params = StringUtils.substringBetween(descriptor, "(", ")");
+                int hackyParamCount = StringUtils.countMatches(params, ';');
+                return hackyParamCount == paramCount;
+
+            }
+            return false;
+        }).findFirst();
+    }
+
+    public static Optional<IBinaryMethod> findMethodWithNoParamsEclipse(ClassFileReader classRepresentation, String methodName) {
+        IBinaryMethod[] methods = classRepresentation.getMethods();
+
+        return Arrays.stream(methods).filter(x1 -> {
+
+            char[] selector = x1.getSelector();
+            String s1 = String.valueOf(selector);
+
+
+            if (s1.equals(methodName)) {
+                char[] methodDescriptor = x1.getMethodDescriptor();
+                IBinaryAnnotation[] annotations = x1.getAnnotations();
+                char[][] exceptionTypeNames = x1.getExceptionTypeNames();
+                char[] genericSignature = x1.getGenericSignature();
+                long tagBits = x1.getTagBits();
+                char[][] argumentNames = x1.getArgumentNames();
+                Object defaultValue = x1.getDefaultValue();
+                IBinaryTypeAnnotation[] typeAnnotations = x1.getTypeAnnotations();
+
+
+                return s1.equals(methodName) && x1.getAnnotatedParametersCount() == 0;
+            }
+
+            return false;
+
+        }).findFirst();
+
+    }
 }

--- a/generator/src/test/java/io/stubbs/truth/generator/internal/CustomClassPathSubjects.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/internal/CustomClassPathSubjects.java
@@ -26,7 +26,7 @@ public class CustomClassPathSubjects {
         Map<String, Project> projectMap = employee.getProjectMap();
 
         //
-        Method getProjectMap = TestModelUtils.findMethod(MyEmployee.class, "getProjectMap");
+        Method getProjectMap = TestModelUtils.findMethodWithNoParamsJRflect(MyEmployee.class, "getProjectMap");
         var subjectForType = subjects.getSubjectForType(getProjectMap.getReturnType());
         assertThat(subjectForType.get().getClazz()).isEqualTo(MyMapSubject.class);
     }

--- a/generator/src/test/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyserTest.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyserTest.java
@@ -1,23 +1,31 @@
 package io.stubbs.truth.generator.internal;
 
-import com.sun.tools.javac.platform.JDKPlatformProvider;
-import com.sun.tools.javac.platform.PlatformDescription;
-import com.sun.tools.javac.platform.PlatformProvider;
-import com.sun.tools.javac.platform.PlatformUtils;
+import com.google.common.truth.Truth8;
+import io.stubbs.truth.generator.TestModelUtils;
+import javassist.bytecode.ClassFile;
+import javassist.bytecode.MethodInfo;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import one.util.streamex.StreamEx;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
+import org.eclipse.jdt.internal.compiler.util.CtSym;
+import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.junit.Assume;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.lang.model.SourceVersion;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.File;
 import java.lang.reflect.Method;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Optional;
-import java.util.ServiceLoader;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -57,21 +65,245 @@ public class JDKOverrideAnalyserTest {
         assertThat(contains).isTrue();
     }
 
+    @SneakyThrows
     @Test
-    public void madscientest() {
+    public void staticMethodInSetCopyOfNotIn9andIsIn10() {
+        Set<Object> objects = Set.copyOf(Set.of());
+
+        {
+            ClassFile classRepresentation = getClassFileEclipse(9, Set.class);
+            Optional<MethodInfo> method = TestModelUtils.findMethodJA(classRepresentation, "copyOf", 1);
+
+            Truth8.assertThat(method).isEmpty();
+        }
+
+        {
+            ClassFile classRepresentation = getClassFileEclipse(10, Set.class);
+            Optional<MethodInfo> method = TestModelUtils.findMethodJA(classRepresentation, "copyOf", 1);
+
+            Truth8.assertThat(method).isPresent();
+        }
+    }
+
+    @SneakyThrows
+    private @Nullable
+    ClassFile getClassFileEclipse(int platformNumber, Class<?> clazz) {
+        String platformName = Integer.toString(platformNumber);
+
+        String qualifiedSigFilename = clazz.getTypeName().replace('.', '/') + ".sig";
+
+        String releaseCode = CtSym.getReleaseCode(platformName);
+        Path java_home = Path.of(System.getenv("JAVA_HOME"));
+        CtSym ctSym = JRTUtil.getCtSym(java_home);
+
+        Optional<Path> fullPath = Optional.ofNullable(ctSym.getFullPath(releaseCode, qualifiedSigFilename, clazz.getModule().getName()));
+
+        if (fullPath.isEmpty())
+            return null;
+
+        byte[] fileBytes = ctSym.getFileBytes(fullPath.get());
+        return new ClassFile(new DataInputStream(new ByteArrayInputStream(fileBytes)));
+    }
+
+    @SneakyThrows
+    @Test
+    public void OptionalOrElseThrow9and10() {
+        String s = Optional.of("").orElseThrow();
+
+        String methodName = "orElseThrow";
+        Class<Optional> clazz = Optional.class;
+
+        test9and10MissingPresent(methodName, clazz);
+    }
+
+    @SneakyThrows
+    private void test9and10MissingPresent(String methodName, Class<?> clazz) {
+        {
+            {
+                ClassFile classRepresentation = getClassFileEclipse(9, clazz);
+                Optional<MethodInfo> method = TestModelUtils.findMethodWithNoParamsJA(classRepresentation, methodName);
+
+                Truth8.assertThat(method).isEmpty();
+
+            }
+        }
+
+        {
+            ClassFile classRepresentation = getClassFileEclipse(10, clazz);
+            Optional<MethodInfo> method = TestModelUtils.findMethodWithNoParamsJA(classRepresentation, methodName);
+
+            Truth8.assertThat(method).isPresent();
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    public void Collector() {
+        String s = Optional.of("").orElseThrow();
+
+        String methodName = "toUnmodifiableList";
+        Class<Collectors> clazz = Collectors.class;
+
+        test9and10MissingPresent(methodName, clazz);
+    }
+
+    @SneakyThrows
+    @Test
+    public void durationInJava9() {
+        long l = Duration.ofSeconds(0).toSeconds();
+
+        ClassFile classRepresentation = getClassFileEclipse(9, Duration.class);
+        Optional<MethodInfo> toSeconds = TestModelUtils.findMethodWithNoParamsJA(classRepresentation, "toSeconds");
+
+        Truth8.assertThat(toSeconds).isPresent();
+    }
+
+    @SneakyThrows
+    @Test
+    public void durationInJava8() {
+        ClassFile classRepresentation = getClassFileEclipse(8, Duration.class);
+
+        Optional<MethodInfo> toSeconds = TestModelUtils.findMethodWithNoParamsJA(classRepresentation, "toSeconds");
+
+        Truth8.assertThat(toSeconds).isEmpty();
+    }
+
+    @SneakyThrows
+    @Test
+    public void java12NewInnerClasses() {
+        Class<Enum.EnumDesc> enumDescClass = Enum.EnumDesc.class;
+
+        ClassFile classRepresentation9 = getClassFileEclipse(9, Enum.EnumDesc.class);
+        assertThat(classRepresentation9).isNull();
+
+        ClassFile classRepresentation12 = getClassFileEclipse(12, Enum.EnumDesc.class);
+        assertThat(classRepresentation12).isNotNull();
+    }
+
+    @SneakyThrows
+    private ClassFileReader getClassFileEclipseDD(int platformNumber, Class<?> clazz) {
+        String platformName = Integer.toString(platformNumber);
+        String packageName = clazz.getPackageName();
+        String className = clazz.getSimpleName() + ".";
 
         JavaCompiler systemJavaCompiler = ToolProvider.getSystemJavaCompiler();
         Set<SourceVersion> sourceVersions = systemJavaCompiler.getSourceVersions();
 
 
-        ServiceLoader<PlatformProvider> load = ServiceLoader.load(PlatformProvider.class);
+//        JDKPlatformProvider jdkPlatformProvider = new JDKPlatformProvider();
+//        Iterable<String> supportedPlatformNames = jdkPlatformProvider.getSupportedPlatformNames();
+//
+//        PlatformDescription platformDescription = PlatformUtils.lookupPlatformDescription("13");
 
-        JDKPlatformProvider jdkPlatformProvider = new JDKPlatformProvider();
-        Iterable<String> supportedPlatformNames = jdkPlatformProvider.getSupportedPlatformNames();
+        String releaseCode = CtSym.getReleaseCode(platformName);
+        Map<String, String> getenv = System.getenv();
+        Properties properties = System.getProperties();
+        Path java_home = Path.of(System.getenv("JAVA_HOME"));
+        CtSym ctSym = JRTUtil.getCtSym(java_home);
+        FileSystem fs = ctSym.getFs();
+        boolean jre12Plus = ctSym.isJRE12Plus();
+        List<Path> paths = ctSym.releaseRoots(releaseCode);
+        String qualifiedSigFilename = clazz.getCanonicalName().replace('.', '/') + ".sig";
+        Path fullPath = ctSym.getFullPath(releaseCode, qualifiedSigFilename, clazz.getModule().getName());
+        byte[] fileBytes = ctSym.getFileBytes(fullPath);
+        String moduleInJre12plus = ctSym.getModuleInJre12plus(releaseCode, qualifiedSigFilename);
 
-        PlatformDescription platformDescription = PlatformUtils.lookupPlatformDescription("");
 
-        log.error("");
+        ClassFileReader classFileReader = new ClassFileReader(fileBytes, clazz.getCanonicalName().toCharArray());
+        return classFileReader;
+//        IBinaryMethod[] methods = classFileReader.getMethods();
+//        Arrays.stream(methods).filter(x->x.toString().contains())
+//
+//        ClassFile eclipseClassRepresentation = new ClassFile(new DataInputStream(new ByteArrayInputStream(fileBytes)));
+//        return eclipseClassRepresentation;
     }
+
+
+//    private ClassFile getClassFile(int platformNumber, Class<?> clazz) throws PlatformProvider.PlatformNotSupported, IOException {
+//        String platformName = Integer.toString(platformNumber);
+//        String packageName = clazz.getPackageName();
+//        String className = clazz.getSimpleName() + ".";
+//
+//        JavaCompiler systemJavaCompiler = ToolProvider.getSystemJavaCompiler();
+//        Set<SourceVersion> sourceVersions = systemJavaCompiler.getSourceVersions();
+//
+//
+////        JDKPlatformProvider jdkPlatformProvider = new JDKPlatformProvider();
+////        Iterable<String> supportedPlatformNames = jdkPlatformProvider.getSupportedPlatformNames();
+////
+////        PlatformDescription platformDescription = PlatformUtils.lookupPlatformDescription("13");
+//
+//        String releaseCode = CtSym.getReleaseCode(platformName);
+//        Map<String, String> getenv = System.getenv();
+//        Properties properties = System.getProperties();
+//        Path java_home = Path.of(System.getenv("JAVA_HOME"));
+//        CtSym ctSym = JRTUtil.getCtSym(java_home);
+//        FileSystem fs = ctSym.getFs();
+//        boolean jre12Plus = ctSym.isJRE12Plus();
+//        List<Path> paths = ctSym.releaseRoots(releaseCode);
+//        String qualifiedSigFilename = clazz.getCanonicalName().replace('.', '/') + ".sig";
+//        Path fullPath = ctSym.getFullPath(releaseCode, qualifiedSigFilename, clazz.getModule().getName());
+//        byte[] fileBytes = ctSym.getFileBytes(fullPath);
+//        String moduleInJre12plus = ctSym.getModuleInJre12plus(releaseCode, qualifiedSigFilename);
+//
+//        ClassFile eclipseClassRepresentation = new ClassFile(new DataInputStream(new ByteArrayInputStream(fileBytes)));
+//
+//        ServiceLoader<PlatformProvider> load = ServiceLoader.load(PlatformProvider.class);
+//
+//        PlatformProvider first = load.findFirst().get();
+//        Iterable<String> supportedPlatformNames = first.getSupportedPlatformNames();
+//        PlatformDescription platform = first.getPlatform(platformName, "");
+//        JavaFileManager fileManager = platform.getFileManager();
+//
+//
+//        List<FileObject> fileObjects = StreamEx.of(StandardLocation.values()).toFlatList(standardLocation -> {
+//            if (standardLocation.isModuleOrientedLocation())
+//                return List.of();
+//            {
+//                String moduleName = null;
+//                try {
+//                    moduleName = fileManager.inferModuleName(standardLocation);
+//                    if (moduleName != null) {
+//                        JavaFileManager.Location locationForModule = fileManager.getLocationForModule(standardLocation, moduleName);
+//                        FileObject fileForInput = fileManager.getFileForInput(standardLocation, packageName, clazz.getSimpleName());
+//                        return fileForInput != null ? List.of(fileForInput) : List.of();
+//                    } else {
+//                        return List.of();
+//                    }
+//                } catch (IOException e) {
+//                    e.printStackTrace();
+//                    return List.of();
+//                }
+//
+//            }
+////
+////            try {
+////                FileObject fileForInput = fileManager.getFileForInput(standardLocation, packageName, clazz.getSimpleName());
+////                return fileForInput != null ? List.of(fileForInput) : List.of();
+////            } catch (IOException e) {
+////                e.printStackTrace();
+////                return List.of();
+////            }
+//        });
+//
+//
+//        Iterable<JavaFileObject> list = fileManager.list(StandardLocation.PLATFORM_CLASS_PATH, packageName, EnumSet.of(JavaFileObject.Kind.OTHER), false);
+//        List<JavaFileObject> iterables = StreamEx.of(list.iterator()).toList();
+//        Optional<JavaFileObject> first1 = StreamEx.of(list.iterator()).filter(x -> x.getName().contains(className)).findFirst();
+//        JavaFileObject durationJFO = first1.get();
+//        JavaFileObject.Kind kind = durationJFO.getKind();
+//        URI uri = durationJFO.toUri();
+//        Modifier accessLevel = durationJFO.getAccessLevel();
+//        NestingKind nestingKind = durationJFO.getNestingKind();
+//
+//        InputStream inputStream = durationJFO.openInputStream();
+//        ClassFile classRepresentation = new ClassFile(new DataInputStream(inputStream));
+//
+//
+////        JavaFileManager fm = pp.getPlatform(release, "").getFileManager();
+//
+//
+//        return classRepresentation;
+//    }
 
 }

--- a/generator/src/test/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyserTest.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyserTest.java
@@ -1,13 +1,21 @@
 package io.stubbs.truth.generator.internal;
 
+import com.sun.tools.javac.platform.JDKPlatformProvider;
+import com.sun.tools.javac.platform.PlatformDescription;
+import com.sun.tools.javac.platform.PlatformUtils;
+import lombok.extern.slf4j.Slf4j;
 import one.util.streamex.StreamEx;
 import org.junit.Assume;
 import org.junit.Test;
 
+import javax.lang.model.SourceVersion;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -17,6 +25,7 @@ import static com.google.common.truth.Truth.assertThat;
  * @author Antony Stubbs
  * @see JDKOverrideAnalyser
  */
+@Slf4j
 public class JDKOverrideAnalyserTest {
 
     File overrideJar = new File("C:\\Users\\anton\\.jdks\\adopt-openjdk-1.8.0_292\\jre\\lib\\rt.jar");
@@ -44,6 +53,23 @@ public class JDKOverrideAnalyserTest {
         Method toSeconds = StreamEx.of(clazz.getMethods()).filter(x -> x.getName().contains("toMillis")).findFirst().get();
         boolean contains = jdkOverrideAnalyser.doesOverrideClassContainMethod(clazz, toSeconds);
         assertThat(contains).isTrue();
+    }
+
+    @Test
+    public void madscientest() {
+
+        JavaCompiler systemJavaCompiler = ToolProvider.getSystemJavaCompiler();
+        Set<SourceVersion> sourceVersions = systemJavaCompiler.getSourceVersions();
+
+
+//        ServiceLoader<PlatformProvider> load = ServiceLoader.load(PlatformProvider.class);
+
+        JDKPlatformProvider jdkPlatformProvider = new JDKPlatformProvider();
+        Iterable<String> supportedPlatformNames = jdkPlatformProvider.getSupportedPlatformNames();
+
+        PlatformDescription platformDescription = PlatformUtils.lookupPlatformDescription("");
+
+        log.error("");
     }
 
 }

--- a/generator/src/test/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyserTest.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/internal/JDKOverrideAnalyserTest.java
@@ -2,6 +2,7 @@ package io.stubbs.truth.generator.internal;
 
 import com.sun.tools.javac.platform.JDKPlatformProvider;
 import com.sun.tools.javac.platform.PlatformDescription;
+import com.sun.tools.javac.platform.PlatformProvider;
 import com.sun.tools.javac.platform.PlatformUtils;
 import lombok.extern.slf4j.Slf4j;
 import one.util.streamex.StreamEx;
@@ -15,6 +16,7 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -62,7 +64,7 @@ public class JDKOverrideAnalyserTest {
         Set<SourceVersion> sourceVersions = systemJavaCompiler.getSourceVersions();
 
 
-//        ServiceLoader<PlatformProvider> load = ServiceLoader.load(PlatformProvider.class);
+        ServiceLoader<PlatformProvider> load = ServiceLoader.load(PlatformProvider.class);
 
         JDKPlatformProvider jdkPlatformProvider = new JDKPlatformProvider();
         Iterable<String> supportedPlatformNames = jdkPlatformProvider.getSupportedPlatformNames();

--- a/generator/src/test/java/io/stubbs/truth/generator/internal/TruthGeneratorTest.java
+++ b/generator/src/test/java/io/stubbs/truth/generator/internal/TruthGeneratorTest.java
@@ -4,6 +4,7 @@ import com.google.common.io.Resources;
 import com.google.common.truth.Correspondence;
 import com.google.common.truth.ObjectArraySubject;
 import io.stubbs.truth.generator.SourceClassSets;
+import io.stubbs.truth.generator.TestModelUtils;
 import io.stubbs.truth.generator.TruthGeneratorAPI;
 import io.stubbs.truth.generator.internal.model.ThreeSystem;
 import io.stubbs.truth.generator.internal.modelSubjectChickens.ThreeSystemChildSubject;
@@ -38,7 +39,6 @@ import java.util.stream.Stream;
 import static com.google.common.truth.Correspondence.from;
 import static com.google.common.truth.Correspondence.transforming;
 import static com.google.common.truth.Truth.assertThat;
-import static io.stubbs.truth.generator.TestModelUtils.findMethod;
 import static io.stubbs.truth.generator.internal.modelSubjectChickens.ThreeSystemChildSubject.assertThat;
 import static java.util.Optional.of;
 
@@ -268,7 +268,7 @@ public class TruthGeneratorTest {
         // map contains strong key, value
         {
             String name = "hasProjectMapWithKey";
-            MethodSource<JavaClassSource> method = findMethod(generated, name);
+            MethodSource<JavaClassSource> method = TestModelUtils.findMethodWithNoParamsRoast(generated, name);
             List<ParameterSource<JavaClassSource>> parameters = method.getParameters();
             assertThat(parameters).comparingElementsUsing(classNames).containsExactly(String.class);
         }
@@ -276,7 +276,7 @@ public class TruthGeneratorTest {
         // list contains strong element
         {
             String name = "hasProjectListWithElement";
-            MethodSource<JavaClassSource> method = findMethod(generated, name);
+            MethodSource<JavaClassSource> method = TestModelUtils.findMethodWithNoParamsRoast(generated, name);
             List<ParameterSource<JavaClassSource>> parameters = method.getParameters();
             assertThat(parameters).comparingElementsUsing(classNames).containsExactly(Project.class);
         }
@@ -307,7 +307,7 @@ public class TruthGeneratorTest {
         // custom string
         {
             String name = "hasName";
-            MethodSource<JavaClassSource> method = findMethod(generatedParent, name);
+            MethodSource<JavaClassSource> method = TestModelUtils.findMethodWithNoParamsRoast(generatedParent, name);
             Type<JavaClassSource> returnType = method.getReturnType();
             assertThat(returnType.getName()).isEqualTo(MyStringSubject.class.getSimpleName());
             assertThat(returnType.getName()).isEqualTo(MyStringSubject.class.getSimpleName());
@@ -316,7 +316,7 @@ public class TruthGeneratorTest {
         // custom map
         {
             String name = "hasProjectMap";
-            MethodSource<JavaClassSource> method = findMethod(generatedParent, name);
+            MethodSource<JavaClassSource> method = TestModelUtils.findMethodWithNoParamsRoast(generatedParent, name);
             Type<JavaClassSource> returnType = method.getReturnType();
             assertThat(returnType.getName()).isEqualTo(MyMapSubject.class.getSimpleName());
         }

--- a/plugin-maven/src/main/java/io/stubbs/truth/generator/plugin/GeneratorMojo.java
+++ b/plugin-maven/src/main/java/io/stubbs/truth/generator/plugin/GeneratorMojo.java
@@ -9,7 +9,6 @@ import io.stubbs.truth.generator.internal.model.ThreeSystem;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
@@ -128,12 +127,15 @@ public class GeneratorMojo extends AbstractMojo {
      */
     @Parameter(property = "truth.recursive", defaultValue = "true")
     public boolean recursive;
+
     /**
-     * Advanced setting - override class source for class reflection. Useful for when runtime env is different than
-     * plugin execution environment - e.g. when building on a newer jdk than running on.
+     * Advanced setting - configure the release target for class reflection. Useful for when runtime env is different
+     * from the execution environment - e.g. when building on a newer jdk than running on. Same as the maven compiler
+     * plugin target option. In fact, we first try to copy the same release target from there, so if that's specified,
+     * this shouldn't be needed.
      */
-    @Parameter(property = "truth.jdkClassSourceOverride")
-    public String jdkClassSourceOverride;
+    @Parameter(property = "truth.releaseTarget")
+    public Integer releaseTarget;
     /**
      * Location of the file.
      */
@@ -222,9 +224,9 @@ public class GeneratorMojo extends AbstractMojo {
                 .useGetterForLegacyClasses(isUseGetterForLegacyClasses())
                 .compilationTargetLowerThanNine(isCompilationTargetBelowJavaNine());
 
-        String jdkClassSourceOverride = getJdkClassSourceOverride();
-        if (StringUtils.isNotBlank(jdkClassSourceOverride)) {
-            optionsBuilder.runtimeJavaClassSourceOverride(Optional.of(new File(jdkClassSourceOverride)));
+        Integer foundReleaseTarget = getReleaseTarget();
+        if (foundReleaseTarget != null) {
+            optionsBuilder.releaseTarget(Optional.of(foundReleaseTarget));
         }
 
         return optionsBuilder.build();

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <flogger.version>0.7.4</flogger.version>
+        <maven.compiler.source>13</maven.compiler.source>
+        <maven.compiler.target>13</maven.compiler.target>
+        <!--        <maven.compiler.source>16</maven.compiler.source>-->
+        <!--        <maven.compiler.target>16</maven.compiler.target>-->
+        <!--        <maven.compiler.target>17</maven.compiler.target>-->
     </properties>
 
     <dependencies>
@@ -271,10 +276,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
+                <!--                <configuration>-->
+                <!--                    <source>16</source>-->
+                <!--                    <target>11</target>-->
+                <!--                </configuration>-->
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Advanced setting - configure the release target for class reflection. Useful for when runtime env is different from the execution environment - e.g. when building on a newer jdk than running on. Same as the maven compiler plugin target option. In fact, we first try to copy the same release target from there, so if that's specified, this shouldn't be needed.