### PR TITLE
build: Clean up pom.xml duplicates and over-broad .gitignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Actions are pinned to SHAs for supply chain security; Dependabot
+    # updates the SHA and the trailing version comment together.

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -1,0 +1,22 @@
+name: PR Dependency Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, closed, reopened]
+
+permissions:
+  issues: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+      # astubbs/dependencies-action is a fork of gregsdennis/dependencies-action
+      # with the feat/auto-unblock-children-on-merge branch (parent PRs unblock
+      # children when merged). SHA pin references that branch tip.
+      - uses: astubbs/dependencies-action@a09974c14e84fb3e4c0df10c04f17bdc6ccc8878 # feat/auto-unblock-children-on-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,29 +9,39 @@ on:
       - master
 
 jobs:
+  actionlint:
+    name: 'Lint workflows'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: 'Run actionlint'
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+
   test:
     name: "JDK ${{ matrix.java }}"
+    needs: actionlint
     strategy:
       matrix:
-        java: [ 17, 18 ]
+        java: [ 17, 21 ]
     runs-on: ubuntu-latest
     steps:
       # Cancel any previous runs for the same branch that are still running.
       - name: 'Cancel previous runs'
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
         with:
           access_token: ${{ github.token }}
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ hashFiles('**/pom.xml') }}
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -49,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -59,7 +69,7 @@ jobs:
             maven-
       #            setup maven settings.xml
       - name: 'Set up Maven settings.xml for Package Cloud'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -78,9 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -88,7 +98,7 @@ jobs:
             maven-
       #            setup maven settings.xml
       - name: 'Set up Maven settings.xml for GitHub'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -108,16 +118,16 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: 'Check out repository'
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #      - name: 'Cache local Maven repository'
-#        uses: actions/cache@v3
+#        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
 #        with:
 #          path: ~/.m2/repository
 #          key: maven-${{ hashFiles('**/pom.xml') }}
 #          restore-keys: |
 #            maven-
 #      - name: 'Set up JDK 11'
-#        uses: actions/setup-java@v3
+#        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
 #        with:
 #          java-version: 11
 #          distribution: 'zulu'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #         with:
 #           ref: ${{ github.event.inputs.branch }}
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: zulu
@@ -63,24 +63,3 @@ jobs:
 
           access-token: ${{ secrets.GITHUB_TOKEN }} # https
           # ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }} # ssh - not used
-
-  # https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven
-  publish_snapshot_github:
-    name: 'Publish snapshot to GitHub Packages'
-    needs: test
-    if: github.event_name == 'push' && github.repository == 'astubbs/truth-generator'
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          releaseVersion=grep scm.tag= | cut  -d= -f2
-          echo $releaseVersion
-      - name: 'Check out repository'
-        uses: actions/checkout@v3
-          with:
-            ref: ${{ releaseVersion }}
-      - name: Publish package
-        run: mvn --batch-mode deploy -DskipTests=true -Pgithub-deploy -P!package-cloud-deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #          As settings.xml gets merged by the tool, we have to include bindings to all variables present - as added above
-          PACKAGE_CLOUD_TOKEN: ${{ secrets.PACKAGE_CLOUD_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,12 @@ target
 .classpath
 .settings
 .clover
-.*
+
+# macOS
+.DS_Store
+
+# Claude Code local worktrees
+.claude/
 
 *.iml
 *.ipr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Project Rules
+
+## Pull Requests
+
+- **When creating a stacked PR, include `depends on #N` in the PR description** (where `#N` is the parent PR it stacks on). This makes the PR dependency gating action (`.github/workflows/check-dependencies.yml`) block the child from merging until the parent is merged. One `depends on` line per parent dependency. Keep the list up to date if the chain changes.

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -112,12 +112,6 @@
             <version>1.2.11</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.24</version>
+                <version>1.18.34</version>
             </dependency>
             <dependency>
                 <groupId>uk.co.jemos.podam</groupId>
@@ -288,16 +288,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
@@ -323,6 +313,14 @@
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.2</version>
+                    <executions>
+                        <execution>
+                            <id>default-test-jar</id>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -378,16 +376,6 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>test-jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -234,21 +234,6 @@
                 <version>${flogger.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.flogger</groupId>
-                <artifactId>flogger-system-backend</artifactId>
-                <version>${flogger.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.flogger</groupId>
-                <artifactId>flogger-maven-backend</artifactId>
-                <version>${flogger.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.flogger</groupId>
-                <artifactId>flogger-log4j2-backend</artifactId>
-                <version>${flogger.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>1.18.24</version>


### PR DESCRIPTION
depends on #159

## Summary
Small, independent cleanup commits plus one new CI workflow.

- **`.gitignore`**: Replace the over-broad `.*` rule with explicit entries (`.DS_Store`, `.claude/`). The old rule was shadowing `.github/`, `.run/`, `.mvn/`, and `.gitignore` itself — `git add .github/...` refused without `-u`/`-f`. The ignores it was actually used for (`.idea/`, `.project`, `.classpath`, `.settings`, `.clover`) were already listed explicitly above the removed line.
- **Duplicate logback-classic**: Exact duplicate declaration removed from `generator/pom.xml`. Maven had been warning about it.
- **Unused flogger backends**: Removed `flogger-system-backend`, `flogger-maven-backend`, `flogger-log4j2-backend` from parent `pom.xml` `<dependencyManagement>`. Only `flogger-slf4j-backend` is actually consumed anywhere. `flogger-system-backend` still resolves transitively at the same version.
- **PR Dependency Check**: New `.github/workflows/check-dependencies.yml` running `astubbs/dependencies-action` on PRs (same workflow used in `astubbs/parallel-consumer@dev/ci-tweak`). Enforces `depends on #N` references in PR descriptions; parents unblock children when merged. Action SHA-pinned.

## Stacked on #159
This branch is merged with `dev-cc` (PR #159) so the local build works. Once #159 lands, the merge commit collapses and this PR's diff against master will show only the four commits above.

## Test plan
- [x] `git status --ignored` unchanged before/after the gitignore fix
- [x] `git check-ignore .github/workflows/ci.yml` returns nothing (no longer shadowed)
- [x] `mvn dependency:tree` output unchanged for flogger
- [x] `mvn clean install` passes all 5 modules locally
- [x] `actionlint` clean on the new workflow
- [ ] CI green on this PR
- [ ] PR Dependency Check appears as a check on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)