### PR TITLE
build: Fix release-drafter failing on pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Actions are pinned to SHAs for supply chain security; Dependabot
+    # updates the SHA and the trailing version comment together.

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -1,0 +1,22 @@
+name: PR Dependency Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, closed, reopened]
+
+permissions:
+  issues: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+      # astubbs/dependencies-action is a fork of gregsdennis/dependencies-action
+      # with the feat/auto-unblock-children-on-merge branch (parent PRs unblock
+      # children when merged). SHA pin references that branch tip.
+      - uses: astubbs/dependencies-action@a09974c14e84fb3e4c0df10c04f17bdc6ccc8878 # feat/auto-unblock-children-on-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,29 +9,39 @@ on:
       - master
 
 jobs:
+  actionlint:
+    name: 'Lint workflows'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: 'Run actionlint'
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+
   test:
     name: "JDK ${{ matrix.java }}"
+    needs: actionlint
     strategy:
       matrix:
-        java: [ 17, 18 ]
+        java: [ 17, 21 ]
     runs-on: ubuntu-latest
     steps:
       # Cancel any previous runs for the same branch that are still running.
       - name: 'Cancel previous runs'
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
         with:
           access_token: ${{ github.token }}
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ hashFiles('**/pom.xml') }}
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -49,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -59,7 +69,7 @@ jobs:
             maven-
       #            setup maven settings.xml
       - name: 'Set up Maven settings.xml for Package Cloud'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -78,9 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -88,7 +98,7 @@ jobs:
             maven-
       #            setup maven settings.xml
       - name: 'Set up Maven settings.xml for GitHub'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -108,16 +118,16 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: 'Check out repository'
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #      - name: 'Cache local Maven repository'
-#        uses: actions/cache@v3
+#        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
 #        with:
 #          path: ~/.m2/repository
 #          key: maven-${{ hashFiles('**/pom.xml') }}
 #          restore-keys: |
 #            maven-
 #      - name: 'Set up JDK 11'
-#        uses: actions/setup-java@v3
+#        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
 #        with:
 #          java-version: 11
 #          distribution: 'zulu'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,13 +2,8 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - master
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #         with:
 #           ref: ${{ github.event.inputs.branch }}
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: zulu
@@ -63,24 +63,3 @@ jobs:
 
           access-token: ${{ secrets.GITHUB_TOKEN }} # https
           # ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }} # ssh - not used
-
-  # https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven
-  publish_snapshot_github:
-    name: 'Publish snapshot to GitHub Packages'
-    needs: test
-    if: github.event_name == 'push' && github.repository == 'astubbs/truth-generator'
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          releaseVersion=grep scm.tag= | cut  -d= -f2
-          echo $releaseVersion
-      - name: 'Check out repository'
-        uses: actions/checkout@v3
-          with:
-            ref: ${{ releaseVersion }}
-      - name: Publish package
-        run: mvn --batch-mode deploy -DskipTests=true -Pgithub-deploy -P!package-cloud-deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #          As settings.xml gets merged by the tool, we have to include bindings to all variables present - as added above
-          PACKAGE_CLOUD_TOKEN: ${{ secrets.PACKAGE_CLOUD_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,12 @@ target
 .classpath
 .settings
 .clover
-.*
+
+# macOS
+.DS_Store
+
+# Claude Code local worktrees
+.claude/
 
 *.iml
 *.ipr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Project Rules
+
+## Pull Requests
+
+- **When creating a stacked PR, include `depends on #N` in the PR description** (where `#N` is the parent PR it stacks on). This makes the PR dependency gating action (`.github/workflows/check-dependencies.yml`) block the child from merging until the parent is merged. One `depends on` line per parent dependency. Keep the list up to date if the chain changes.

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -112,12 +112,6 @@
             <version>1.2.11</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.24</version>
+                <version>1.18.34</version>
             </dependency>
             <dependency>
                 <groupId>uk.co.jemos.podam</groupId>
@@ -288,16 +288,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
@@ -323,6 +313,14 @@
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.2</version>
+                    <executions>
+                        <execution>
+                            <id>default-test-jar</id>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -378,16 +376,6 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>test-jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -234,21 +234,6 @@
                 <version>${flogger.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.flogger</groupId>
-                <artifactId>flogger-system-backend</artifactId>
-                <version>${flogger.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.flogger</groupId>
-                <artifactId>flogger-maven-backend</artifactId>
-                <version>${flogger.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.flogger</groupId>
-                <artifactId>flogger-log4j2-backend</artifactId>
-                <version>${flogger.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>1.18.24</version>


### PR DESCRIPTION
depends on #160

## Summary
Remove the `pull_request` trigger from the release-drafter workflow. On PR events, the action tried to update the draft release with `refs/pull/N/merge` as the `target_commitish`, which the GitHub Release API rejects (`Validation Failed: invalid target_commitish`).

The trigger was originally for autolabeling PRs, but no autolabeler rules are configured in `.github/release-drafter.yml`, so it did nothing useful. The workflow now only runs on push to master, where updating the draft release actually works.

## Test plan
- [x] `actionlint` clean
- [ ] CI green — `update_release_draft` check should no longer appear (or fail) on PRs
- [ ] On next push to master, release draft is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)